### PR TITLE
Fix the ds4drv-pair script for Bionic

### DIFF
--- a/scripts/ds4drv-pair
+++ b/scripts/ds4drv-pair
@@ -6,7 +6,7 @@ puts "Searching for PS4 Controller..."
 log_user 0
 set prompt "#"
 
-spawn bluetoothctl -a
+spawn bluetoothctl
 expect "Agent registered"
 expect $prompt
 

--- a/udev/50-ds4drv.rules
+++ b/udev/50-ds4drv.rules
@@ -4,4 +4,4 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:05C4.*", MODE="0666"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="09cc", MODE="0666"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:09CC.*", MODE="0666"
-KERNEL=="js*", SUBSYSTEM=="input", ATTRS{name}=="Xbox 360 Wireless Receiver", MODE="0666", SYMLINK+="input/ds4x"
+KERNEL=="js*", SUBSYSTEM=="input", ATTRS{name}=="Wireless Controller", MODE="0666", SYMLINK+="input/ds4x"


### PR DESCRIPTION
And update the udev rule since PS4 controllers are not named "Xbox 360 Wireless Receiver" on the new system either.