### PR TITLE
Add /dev/input/ps4 symlink to udev rule

### DIFF
--- a/udev/50-ds4drv.rules
+++ b/udev/50-ds4drv.rules
@@ -4,4 +4,4 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:05C4.*", MODE="0666"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="09cc", MODE="0666"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:09CC.*", MODE="0666"
-KERNEL=="js*", SUBSYSTEM=="input", ATTRS{name}=="Wireless Controller", MODE="0666", SYMLINK+="input/ds4x"
+KERNEL=="js*", SUBSYSTEM=="input", ATTRS{name}=="Wireless Controller", MODE="0666", SYMLINK+="input/ds4x", SYMLINK+="input/ps4"


### PR DESCRIPTION
As part of consolidating the udev rules and to reduce floating rules that our ISOs install, create the .../ps4 symlink here.  This symlink is required to compatibility with the Melodic branches of Jackal, Husky, Dingo, Ridgeback, etc...