### PR TITLE
Fix the AutoEnable issues we've been seeing recently

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -8,7 +8,7 @@ if [ -e /etc/init.d/ds4drv ]; then
 fi
 
 if [ -e /etc/bluetooth/main.conf ]; then
-  echo "AutoEnable=true#ds4drv#" >> /etc/bluetooth/main.conf
+  echo "AutoEnable=true #ds4drv#" >> /etc/bluetooth/main.conf
 fi
 
 #DEBHELPER

--- a/debian/postinst
+++ b/debian/postinst
@@ -8,7 +8,14 @@ if [ -e /etc/init.d/ds4drv ]; then
 fi
 
 if [ -e /etc/bluetooth/main.conf ]; then
-  echo "AutoEnable=true #ds4drv#" >> /etc/bluetooth/main.conf
+  # remove the addition from previous versions of this package!
+  sed -i -e 's/AutoEnable=true#ds4drv#//g' /etc/bluetooth/main.conf
+
+  # ensure AutoEnable is true
+  if ! grep -q "AutoEnable=true" /etc/bluetooth/main.conf;
+  then
+    echo "AutoEnable=true #ds4drv#" >> /etc/bluetooth/main.conf
+  fi
 fi
 
 #DEBHELPER

--- a/debian/postrm
+++ b/debian/postrm
@@ -8,7 +8,7 @@ if [ -e /etc/init.d/ds4drv ]; then
 fi
 
 if [ -e /etc/bluetooth/main.conf ]; then
-  sed -i -e 's/AutoEnable=true#ds4drv#//g' /etc/bluetooth/main.conf
+  sed -i -e 's/AutoEnable=true #ds4drv#//g' /etc/bluetooth/main.conf
 fi
 
 #DEBHELPER


### PR DESCRIPTION
Modify the post-install script so that it:
1- removes the old problematic addition to the script
2- only adds AutoEnable=true if that's not already in the file
3- adds a space between the AutoEnable=true and the comment indicating it was added by this package

Post-removal script is also modified to check for the space when cleaning up.