### PR TITLE
Change shebang to explicitly use python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup
 


### PR DESCRIPTION
When we included `python-is-python3` by default this wasn't an issue.  It appears to be a problem now.