### PR TITLE
Set shebang in generated console scripts to explicitly use Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,12 @@
 
 from setuptools import setup
 
+import sys
+
 readme = open("README.rst").read()
 history = open("HISTORY.rst").read()
+
+sys.executable = "/usr/bin/python3"
 
 setup(name="ds4drv",
       version="0.5.5",
@@ -14,7 +18,9 @@ setup(name="ds4drv",
       license="MIT",
       long_description=readme + "\n\n" + history,
       entry_points={
-        "console_scripts": ["ds4drv=ds4drv.__main__:main"]
+        "console_scripts": [
+          "ds4drv=ds4drv.__main__:main"
+        ]
       },
       packages=["ds4drv",
                 "ds4drv.actions",


### PR DESCRIPTION
This will set the shebang in any console scripts (it's actually just the `/usr/sbin/ds4drv`) generated by setup tools to `/usr/bin/python3` instead of `/usr/bin/python`. Otherwise, with the latter, the `ds4drv` service will fail to run on our Ubuntu 20.04 ISO, since `python` is not symlinked to `python3` by default anymore.